### PR TITLE
DragonCore | TimeTravel Command Update

### DIFF
--- a/src/main/java/com/whixard/dragoncore/Main.kt
+++ b/src/main/java/com/whixard/dragoncore/Main.kt
@@ -5,6 +5,7 @@ import com.whixard.dragoncore.api.DragonCoreExpansion
 import com.whixard.dragoncore.api.DragonDatabase
 import com.whixard.dragoncore.api.manager.DragonManager
 import com.whixard.dragoncore.commands.TimeTravelCommand
+import com.whixard.dragoncore.commands.TimeTravelTabCompleter
 import com.whixard.dragoncore.commands.chatfilter.ChatSettings
 import com.whixard.dragoncore.commands.otherplugins.BloodMoonStatus
 import com.whixard.dragoncore.commands.playercommands.Fly
@@ -124,6 +125,7 @@ class Main : JavaPlugin() {
         if (DragonAPI().getConfig().getBoolean("beta_features")) {
             logger.log(Level.INFO, "Beta features are enabled")
             getCommand("timetravel")?.setExecutor(TimeTravelCommand)
+            getCommand("timetravel")?.tabCompleter = TimeTravelTabCompleter
             this.registerEvent(BetaEvents(), "HelloPlayer", this)
         } else {
             logger.log(Level.INFO, "Beta features are disabled")

--- a/src/main/java/com/whixard/dragoncore/commands/TimeTravelCommand.kt
+++ b/src/main/java/com/whixard/dragoncore/commands/TimeTravelCommand.kt
@@ -1,8 +1,13 @@
 package com.whixard.dragoncore.commands
 
 import com.whixard.dragoncore.Main
+import com.whixard.dragoncore.format.Format
+import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.Sound
+import org.bukkit.boss.BarColor
+import org.bukkit.boss.BarFlag
+import org.bukkit.boss.BarStyle
 import org.bukkit.boss.BossBar
 import org.bukkit.command.Command
 import org.bukkit.command.CommandExecutor
@@ -42,23 +47,37 @@ object TimeTravelCommand: CommandExecutor {
         }
 
         if (sender.hasPermission("dragoncore.timetravelevent")) {
+
             if (args[0] == "start") {
                 if (pre_bossbar == null) {
-                    for (player in sender.server.onlinePlayers) {
+                    for (player in Main.instance.server.onlinePlayers) {
                         player.playSound(player.location, Sound.BLOCK_PORTAL_TRAVEL,100F, 1F)
                     }
-                    pre_bossbar = sender.server.createBossBar("Time Travel Event", org.bukkit.boss.BarColor.PURPLE, org.bukkit.boss.BarStyle.SOLID)
-                    pre_bossbar!!.addFlag(org.bukkit.boss.BarFlag.CREATE_FOG)
-                    pre_bossbar!!.addFlag(org.bukkit.boss.BarFlag.DARKEN_SKY)
+                    pre_bossbar = Bukkit.createBossBar(Format.color("&f Sta per cominciare &c- &dViaggio del Drago"), BarColor.PURPLE, BarStyle.SOLID)
+                    pre_bossbar!!.addFlag(BarFlag.CREATE_FOG)
+                    pre_bossbar!!.addFlag(BarFlag.DARKEN_SKY)
                     pre_bossbar!!.isVisible = true
                     pre_bossbar!!.progress = 1.0
-                    for (player in sender.server.onlinePlayers) {
+                    for (player in Main.instance.server.onlinePlayers) {
                         pre_bossbar!!.addPlayer(player)
                     }
-                    sender.server.broadcastMessage("Time Travel Event starting in 10 seconds")
-                    preStartTimer(args[1].toInt())
+                    sender.server.broadcastMessage(Format.color("&dEvento viaggio del Drago inizierà tra 10 secondi."))
+                    sender.server.broadcastMessage(Format.color("&7È consigliabile svuotarsi l'inventario!"))
+                    preStartTimer()
                 }
 
+
+            }
+            if (args[0] == "stop") {
+
+                if(bossbar == null){
+
+                    sender.sendMessage(Format.color("&cNon si sta svolgendo nessun viaggio del Drago al momento."))
+                    return true
+
+                }
+
+                bossbar?.progress=0.1
 
             }
         }
@@ -66,7 +85,7 @@ object TimeTravelCommand: CommandExecutor {
     }
 
 
-    private fun preStartTimer(timer: Int) {
+    private fun preStartTimer() {
         object : BukkitRunnable() {
             override fun run() {
                 if (pre_bossbar != null) {
@@ -77,20 +96,20 @@ object TimeTravelCommand: CommandExecutor {
                         pre_bossbar!!.removeAll()
                         pre_bossbar = null
                         cancel()
-                        startTimer(timer)
+                        startTimer()
                     }
                 }
             }
         }.runTaskTimer(Main.instance, 0, 20)
     }
 
-    private fun startTimer(timer: Int) {
-        bossbar = Main.instance.server.createBossBar("Time Travel Event", org.bukkit.boss.BarColor.PURPLE, org.bukkit.boss.BarStyle.SOLID)
+    private fun startTimer() {
+        bossbar = Bukkit.createBossBar(Format.color("&d&lViaggio del Drago"), BarColor.PURPLE, BarStyle.SOLID)
         bossbar!!.isVisible = true
         bossbar!!.progress = 1.0
-        bossbar!!.addFlag(org.bukkit.boss.BarFlag.CREATE_FOG)
-        bossbar!!.addFlag(org.bukkit.boss.BarFlag.DARKEN_SKY)
-        bossbar!!.style = org.bukkit.boss.BarStyle.SEGMENTED_10
+        bossbar!!.addFlag(BarFlag.CREATE_FOG)
+        bossbar!!.addFlag(BarFlag.DARKEN_SKY)
+        bossbar!!.style = BarStyle.SEGMENTED_10
 
         for (player in Main.instance.server.onlinePlayers) {
             bossbar!!.addPlayer(player)
@@ -99,8 +118,8 @@ object TimeTravelCommand: CommandExecutor {
         object : BukkitRunnable() {
             override fun run() {
                 if (bossbar != null) {
-                    if (bossbar!!.progress > 0.1) {
-                        bossbar!!.progress -= 0.1
+                    if (bossbar!!.progress > 0.1) { // CA. 39 CICLI ESATTI ( 0.025 * 40 = 1)
+                        bossbar!!.progress -= 0.025
                     } else {
                         bossbar!!.isVisible = false
                         bossbar!!.removeAll()
@@ -119,7 +138,7 @@ object TimeTravelCommand: CommandExecutor {
     private fun giveItems() {
         for (player in Main.instance.server.onlinePlayers) {
             val world = player.world
-            world.dropItem(player.location.add(0.0, 5.0, 0.0), items.values.random())
+            world.dropItem(player.location.add(0.0, 2.0, 0.0), items.values.random())
             player.playSound(player.location, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 100F, 1F)
         }
     }

--- a/src/main/java/com/whixard/dragoncore/commands/TimeTravelCommand.kt
+++ b/src/main/java/com/whixard/dragoncore/commands/TimeTravelCommand.kt
@@ -2,8 +2,11 @@ package com.whixard.dragoncore.commands
 
 import com.whixard.dragoncore.Main
 import com.whixard.dragoncore.format.Format
+import net.md_5.bungee.api.ChatMessageType
+import net.md_5.bungee.api.chat.TextComponent
 import org.bukkit.Bukkit
 import org.bukkit.Material
+import org.bukkit.Particle
 import org.bukkit.Sound
 import org.bukkit.boss.BarColor
 import org.bukkit.boss.BarFlag
@@ -14,6 +17,7 @@ import org.bukkit.command.CommandExecutor
 import org.bukkit.command.CommandSender
 import org.bukkit.inventory.ItemStack
 import org.bukkit.scheduler.BukkitRunnable
+import javax.swing.Action
 
 
 object TimeTravelCommand: CommandExecutor {
@@ -25,24 +29,28 @@ object TimeTravelCommand: CommandExecutor {
         items["diamond"] = ItemStack(Material.DIAMOND)
         items["diamond"]!!.amount = 3
         items["diamond"]!!.itemMeta = items["diamond"]!!.itemMeta?.apply {
+            setDisplayName(Format.color("&bDiamante"))
             lore = listOf("Time Traveler")
         }
 
         items["gold"] = ItemStack(Material.GOLD_INGOT)
         items["gold"]!!.amount = 10
         items["gold"]!!.itemMeta = items["gold"]!!.itemMeta?.apply {
+            setDisplayName(Format.color("&6Lingotto d'oro"))
             lore = listOf("Time Traveler")
         }
 
         items["iron"] = ItemStack(Material.IRON_INGOT)
         items["iron"]!!.amount = 20
         items["iron"]!!.itemMeta = items["iron"]!!.itemMeta?.apply {
+            setDisplayName(Format.color("&fLingotto di ferro"))
             lore = listOf("Time Traveler")
         }
 
         items["ancient"] = ItemStack(Material.ANCIENT_DEBRIS)
         items["ancient"]!!.amount = 1
         items["ancient"]!!.itemMeta = items["ancient"]!!.itemMeta?.apply {
+            setDisplayName(Format.color("&8Detrito antico"))
             lore = listOf("Time Traveler")
         }
 
@@ -53,7 +61,7 @@ object TimeTravelCommand: CommandExecutor {
                     for (player in Main.instance.server.onlinePlayers) {
                         player.playSound(player.location, Sound.BLOCK_PORTAL_TRAVEL,100F, 1F)
                     }
-                    pre_bossbar = Bukkit.createBossBar(Format.color("&f Sta per cominciare &c- &dViaggio del Drago"), BarColor.PURPLE, BarStyle.SOLID)
+                    pre_bossbar = Bukkit.createBossBar(Format.color("&fAvvio... &c- &dViaggio del Drago"), BarColor.PURPLE, BarStyle.SOLID)
                     pre_bossbar!!.addFlag(BarFlag.CREATE_FOG)
                     pre_bossbar!!.addFlag(BarFlag.DARKEN_SKY)
                     pre_bossbar!!.isVisible = true
@@ -61,8 +69,8 @@ object TimeTravelCommand: CommandExecutor {
                     for (player in Main.instance.server.onlinePlayers) {
                         pre_bossbar!!.addPlayer(player)
                     }
-                    sender.server.broadcastMessage(Format.color("&dEvento viaggio del Drago inizierà tra 10 secondi."))
-                    sender.server.broadcastMessage(Format.color("&7È consigliabile svuotarsi l'inventario!"))
+                    sender.server.broadcastMessage(Format.color("&f&lEvento &f- &d&lViaggio del Drago&7 comincierà tra 10 secondi."))
+                    sender.server.broadcastMessage(Format.color("&4&l!! &7È consigliabile svuotarsi l'inventario!"))
                     preStartTimer()
                 }
 
@@ -77,6 +85,7 @@ object TimeTravelCommand: CommandExecutor {
 
                 }
 
+                sender.server.broadcastMessage(Format.color("&dEvento viaggio del Drago &cannullato da un'amministratore."))
                 bossbar?.progress=0.1
 
             }
@@ -121,6 +130,9 @@ object TimeTravelCommand: CommandExecutor {
                     if (bossbar!!.progress > 0.1) { // CA. 39 CICLI ESATTI ( 0.025 * 40 = 1)
                         bossbar!!.progress -= 0.025
                     } else {
+                        for(player in Main.instance.server.onlinePlayers){
+                            player.playSound(player.location,Sound.ENTITY_ENDER_DRAGON_DEATH,0.35f,1f)
+                        }
                         bossbar!!.isVisible = false
                         bossbar!!.removeAll()
                         bossbar = null
@@ -135,11 +147,35 @@ object TimeTravelCommand: CommandExecutor {
         }.runTaskTimer(Main.instance, 0, 20)
     }
 
+    var conta_give = 0;
     private fun giveItems() {
         for (player in Main.instance.server.onlinePlayers) {
+
+
             val world = player.world
-            world.dropItem(player.location.add(0.0, 2.0, 0.0), items.values.random())
-            player.playSound(player.location, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 100F, 1F)
+
+            var oggetto = items.values.random();
+            player.spigot().sendMessage(ChatMessageType.ACTION_BAR,TextComponent(Format.color("&f&l + &f"+oggetto.amount+"x "+oggetto.itemMeta?.displayName)))
+            if(player.inventory.firstEmpty()==-1) world.dropItem(player.location, oggetto)
+            else player.inventory.addItem(oggetto)
+
+
+
+
+            if(conta_give>3){
+
+                player.playSound(player.location, Sound.ENTITY_ENDER_DRAGON_GROWL, 50F, 1F)
+                player.playSound(player.location, Sound.ENTITY_ENDER_DRAGON_AMBIENT, 50F, 1F)
+
+            }else{
+                player.playSound(player.location, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 100F, 1F)
+            }
+
+            player.world.spawnParticle(Particle.PORTAL,player.location,500,5.0,2.0,5.0)
+            player.world.spawnParticle(Particle.DRAGON_BREATH,player.location,500,5.0,2.0,5.0)
+
         }
+        if(conta_give>3) conta_give = 0
+        else conta_give++
     }
 }

--- a/src/main/java/com/whixard/dragoncore/commands/TimeTravelTabCompleter.kt
+++ b/src/main/java/com/whixard/dragoncore/commands/TimeTravelTabCompleter.kt
@@ -1,0 +1,20 @@
+package com.whixard.dragoncore.commands
+
+import org.bukkit.command.Command
+import org.bukkit.command.CommandSender
+import org.bukkit.command.TabCompleter
+import java.util.*
+
+object TimeTravelTabCompleter : TabCompleter{
+    override fun onTabComplete(
+        sender: CommandSender,
+        command: Command,
+        label: String,
+        args: Array<out String>
+    ): MutableList<String>? {
+
+
+        return Arrays.asList("start","stop");
+
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -84,7 +84,6 @@ commands:
     permission: dragoncore.randomtp
   timetravel:
     description: "Time Travel"
-    usage: /timetravel <seconds>
     permission: dragoncore.timetravel
   friends:
     description: "Friends"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -84,6 +84,7 @@ commands:
     permission: dragoncore.randomtp
   timetravel:
     description: "Time Travel"
+    usage: /timetravel
     permission: dragoncore.timetravel
   friends:
     description: "Friends"


### PR DESCRIPTION
Changelogs:

- Use of the command will be `/timetravel <start/stop>`
- Better looking bossbar estetics.
- The duration of the Time Trave will be 40 seconds, it may be stopped by administrators manually with `/timetravel stop` command.