### PR TITLE
Added Admin Alert when TPS are to low

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ repositories {
     maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
     maven { url = 'https://oss.sonatype.org/content/repositories/central' }
     maven { url = 'https://jitpack.io' }
+    maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
+
     mavenLocal()
     mavenCentral() // This is needed for CraftBukkit and Spigot.
 }
@@ -49,6 +51,7 @@ dependencies {
     compileOnly 'org.apache.httpcomponents:httpclient:4.5.14'
     compileOnly "com.github.MilkBowl:VaultAPI:1.7"
     compileOnly 'me.clip:placeholderapi:2.11.2'
+    compileOnly 'me.lucko:spark-api:0.1-SNAPSHOT'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     implementation("com.google.guava:guava:31.1-jre")
     implementation 'org.mariadb.jdbc:mariadb-java-client:2.1.2'

--- a/src/main/java/com/whixard/dragoncore/api/DragonAPI.kt
+++ b/src/main/java/com/whixard/dragoncore/api/DragonAPI.kt
@@ -2,24 +2,26 @@
 
 package com.whixard.dragoncore.api
 
+import com.whixard.dragoncore.Main
 import com.whixard.dragoncore.api.manager.DragonManager
 import com.whixard.dragoncore.events.NBTBlock
 import com.whixard.dragoncore.format.Format
+import jdk.jfr.Percentage
+import me.lucko.spark.api.Spark
+import me.lucko.spark.api.statistic.StatisticWindow
+import me.lucko.spark.api.statistic.types.DoubleStatistic
+import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.configuration.file.FileConfiguration
 import org.bukkit.inventory.Inventory
 import org.bukkit.inventory.ItemStack
-
+import org.bukkit.plugin.RegisteredServiceProvider
 import java.util.*
+import kotlin.math.max
+
 
 class DragonAPI {
 
-
-    fun addBalance(amount: Double){
-
-
-
-    }
 
     fun getBackEnd(): com.whixard.dragoncore.Main? {
         return DragonManager(com.whixard.dragoncore.Main.instance).getBackEnd()
@@ -62,6 +64,15 @@ class DragonAPI {
 
     fun getConfig(): FileConfiguration {
         return com.whixard.dragoncore.Main.instance.config
+    }
+
+    fun getServerTPS() : DoubleStatistic<StatisticWindow.TicksPerSecond>? {
+        return Bukkit.getServicesManager().getRegistration(Spark::class.java)?.provider?.tps()
+    }
+
+
+    fun getServerUsingRamPercentage() : Int { // from 0 to 100
+        return (((Runtime.getRuntime().maxMemory()-Runtime.getRuntime().freeMemory()))/(Runtime.getRuntime().maxMemory())).toInt()
     }
 
     fun getPlugins(): List<String> {

--- a/src/main/java/com/whixard/dragoncore/commands/TimeTravelCommand.kt
+++ b/src/main/java/com/whixard/dragoncore/commands/TimeTravelCommand.kt
@@ -71,7 +71,7 @@ object TimeTravelCommand: CommandExecutor {
                     }
                     sender.server.broadcastMessage(Format.color("&f&lEvento &f- &d&lViaggio del Drago&7 comincierà tra 10 secondi."))
                     sender.server.broadcastMessage(Format.color("&4&l!! &7È consigliabile svuotarsi l'inventario!"))
-                    preStartTimer()
+                    preStartTimer(sender)
                 }
 
 
@@ -94,7 +94,7 @@ object TimeTravelCommand: CommandExecutor {
     }
 
 
-    private fun preStartTimer() {
+    private fun preStartTimer(sender: CommandSender) {
         object : BukkitRunnable() {
             override fun run() {
                 if (pre_bossbar != null) {
@@ -105,14 +105,14 @@ object TimeTravelCommand: CommandExecutor {
                         pre_bossbar!!.removeAll()
                         pre_bossbar = null
                         cancel()
-                        startTimer()
+                        startTimer(sender)
                     }
                 }
             }
         }.runTaskTimer(Main.instance, 0, 20)
     }
 
-    private fun startTimer() {
+    private fun startTimer(sender : CommandSender) {
         bossbar = Bukkit.createBossBar(Format.color("&d&lViaggio del Drago"), BarColor.PURPLE, BarStyle.SOLID)
         bossbar!!.isVisible = true
         bossbar!!.progress = 1.0
@@ -141,14 +141,14 @@ object TimeTravelCommand: CommandExecutor {
                 }
                 // Randomly decide if we should give items
                 if (Math.random() < 0.5) {
-                    giveItems()
+                    giveItems(sender)
                 }
             }
         }.runTaskTimer(Main.instance, 0, 20)
     }
 
     var conta_give = 0;
-    private fun giveItems() {
+    private fun giveItems(sender : CommandSender) {
         for (player in sender.server.onlinePlayers) {
 
             val world = player.world

--- a/src/main/java/com/whixard/dragoncore/events/ResourcesMonitoring/RM_AlertInProgress.kt
+++ b/src/main/java/com/whixard/dragoncore/events/ResourcesMonitoring/RM_AlertInProgress.kt
@@ -1,0 +1,66 @@
+package com.whixard.dragoncore.events.ResourcesMonitoring
+
+import com.whixard.dragoncore.Main
+import com.whixard.dragoncore.api.DragonAPI
+import com.whixard.dragoncore.format.Format
+import me.lucko.spark.api.statistic.StatisticWindow
+import net.md_5.bungee.api.ChatMessageType
+import net.md_5.bungee.api.chat.TextComponent
+import org.bukkit.Sound
+import org.bukkit.entity.Player
+import org.bukkit.scheduler.BukkitRunnable
+
+class RM_AlertInProgress : BukkitRunnable() {
+
+    val api : DragonAPI = DragonAPI()
+
+    override fun run() {
+
+        if(api.getServerTPS()?.poll(StatisticWindow.TicksPerSecond.SECONDS_10)!! > api.getConfig().getDouble("alerts.tps-when-under")){
+
+            Main.instance.is_resources_alert_running = false
+
+            for(player in Main.instance.server.onlinePlayers){
+
+                if(player.hasPermission("dragoncore.see_resources_alerts")){
+
+                    player.sendTitle("", Format.color("&c&lAlert finished, we are safe!"),0,100,0)
+                    player.playSound(player, Sound.ENTITY_PLAYER_LEVELUP,100f,0.9f)
+
+                }
+
+            }
+
+            Main.instance.TPS_Alert_BossBar!!.isVisible = false
+            //Main.instance.RAM_Alert_BossBar!!.isVisible = false
+
+            Main.instance.TPS_Alert_BossBar!!.progress = 0.1
+            //Main.instance.RAM_Alert_BossBar!!.progress = 0.0
+
+            this.cancel()
+
+        }
+        else{
+
+            if((api.getServerTPS()!!.poll(StatisticWindow.TicksPerSecond.SECONDS_5) / 20.0) >=0 && (api.getServerTPS()!!.poll(StatisticWindow.TicksPerSecond.SECONDS_5) / 20.0) <=20){
+
+                Main.instance.TPS_Alert_BossBar!!.progress = (api.getServerTPS()!!.poll(StatisticWindow.TicksPerSecond.SECONDS_5) / 20.0)
+                Main.instance.TPS_Alert_BossBar!!.setTitle(Format.color("&fTPS: &c"+String.format("%.1f", api.getServerTPS()!!.poll(StatisticWindow.TicksPerSecond.SECONDS_5))))
+
+            }
+
+
+
+            //Main.instance.RAM_Alert_BossBar!!.progress = api.getServerUsingRamPercentage().toDouble()/100
+            //Main.instance.RAM_Alert_BossBar!!.setTitle(Format.color("&fRAM USAGE: &c"+api.getServerUsingRamPercentage()+"%"))
+
+        }
+
+
+
+
+
+
+    }
+
+}

--- a/src/main/java/com/whixard/dragoncore/events/ResourcesMonitoring/RM_Events.kt
+++ b/src/main/java/com/whixard/dragoncore/events/ResourcesMonitoring/RM_Events.kt
@@ -1,0 +1,33 @@
+package com.whixard.dragoncore.events.ResourcesMonitoring
+
+import com.whixard.dragoncore.Main
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.event.player.PlayerQuitEvent
+
+class RM_Events : Listener {
+
+    @EventHandler
+    fun onJoin(e: PlayerJoinEvent){
+
+        if(e.player.hasPermission("dragoncore.see_resources_alerts")){
+            //Main.instance.RAM_Alert_BossBar!!.addPlayer(e.player)
+            Main.instance.TPS_Alert_BossBar!!.addPlayer(e.player)
+        }
+
+    }
+
+    @EventHandler
+    fun onQuit(e: PlayerQuitEvent){
+
+        /*if(Main.instance.RAM_Alert_BossBar!!.players.contains(e.player)){
+            Main.instance.RAM_Alert_BossBar!!.removePlayer(e.player)
+        }*/
+        if(Main.instance.TPS_Alert_BossBar!!.players.contains(e.player)){
+            Main.instance.TPS_Alert_BossBar!!.removePlayer(e.player)
+        }
+
+    }
+
+}

--- a/src/main/java/com/whixard/dragoncore/events/ResourcesMonitoring/RM_Generic.kt
+++ b/src/main/java/com/whixard/dragoncore/events/ResourcesMonitoring/RM_Generic.kt
@@ -1,0 +1,51 @@
+package com.whixard.dragoncore.events.ResourcesMonitoring
+
+import com.whixard.dragoncore.Main
+import com.whixard.dragoncore.api.DragonAPI
+import com.whixard.dragoncore.format.Format
+import me.lucko.spark.api.statistic.StatisticWindow
+import net.md_5.bungee.api.ChatMessageType
+import net.md_5.bungee.api.chat.TextComponent
+import org.bukkit.Bukkit
+import org.bukkit.Sound
+import org.bukkit.boss.BarColor
+import org.bukkit.boss.BarFlag
+import org.bukkit.boss.BarStyle
+import org.bukkit.scheduler.BukkitRunnable
+
+class RM_Generic : BukkitRunnable() {   // Runs everytime and anytime
+
+    val api : DragonAPI = DragonAPI()
+
+    override fun run() {
+
+        if(api.getServerTPS()?.poll(StatisticWindow.TicksPerSecond.SECONDS_10)!! < api.getConfig().getDouble("alerts.tps-when-under") && !Main.instance.is_resources_alert_running){
+
+
+            for(player in Main.instance.server.onlinePlayers){
+
+                if(player.hasPermission("dragoncore.see_resources_alerts")){
+
+                    player.sendTitle("", Format.color("&c&lCritical Error: &cResources lacking!"),0,100,0)
+                    player.playSound(player, Sound.ENTITY_ENDERMAN_DEATH,50f,0.3f)
+
+
+
+                }
+
+            }
+
+            Main.instance.is_resources_alert_running = true
+
+            //Main.instance.RAM_Alert_BossBar!!.isVisible = true
+            Main.instance.TPS_Alert_BossBar!!.isVisible = true
+
+            RM_AlertInProgress().runTaskTimerAsynchronously(Main.instance,0,20)
+
+
+
+        }
+
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -51,3 +51,7 @@ statistics_api:
   url: ""
 
 salutiplayers: ["Ciao {player_name}!", "Come va {player_name}?"]
+
+alerts:
+  ram-when-over: 50 #COUNTS THE PERCENTAGE!
+  tps-when-under: 18


### PR DESCRIPTION
# TPS ALERT

> Todo: add in the dependency of the plugin.yml 'Spark' plugin which is used to read the TPS amount.

#### **What does it do?**

- It sets up and uses a BossBar that is **refreshed each 20 ticks** during the **TPS ALERT** that displays the actual **TPS**.
- It sends titles to all the online administrators to warn them that the TPS is below the safe amount.
- It sends titles to all the online administrators to warn them that the **TPS ALERT** has ended; which means TPS is now above the safe amount.

PS. You can decide the safe amount of **TPS** in the `config.yml` file.

#### **W.I.P.**

In the Next Update, I'll be adding the **RAM ALERT** if possible which will start when the percentage of the used ram will go above a safe limit decided in the config.yml

_If it won't be possible for me to add the **RAM ALERT**, I'll be removing the variables that I've already prepared in the DragonCore_.